### PR TITLE
WIP: add maintain info and scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,47 @@ Here the state of each branch
  III-06_   III-06_polymorphism_      |III-06-travis|   |III-06-coverage|
  ========= ========================= ================= ===================
 
+maintain
+--------
 
-* Free software: Mozilla Public License Version 2.0
+.. warning:
+
+    We often use force pushing (``git push --force``)  in this repository
+
+
+Why
+~~~
+
+- To automate change propagation over the book using rebases.
+- Provide to AnyBlok beginners reading the AnyBlok book a linear commit history
+
+How
+~~~
+
+In this master branch, a script is provided to automaticly rebase
+all child branches according their names. If a rebase has conflict
+the script will stop to let you fix it before carry on.
+
+So you can introduce a change somewhere in the book and it will be
+visible in all following branches to recreate a linear history
+from where you introduce that change.
+
+* Checkout the branche and introduce your change
+* commit that change
+* clone this repo and checkout the master branch in an other directory on
+  your computer
+* run apply changes in next chapters script to rebase all next chapters
+* run test all to run test on each branches
+* run push all to push using the force on each branches
+
+
+
+License
+-------
+
+`Free software: Mozilla Public License Version 2.0
+<http://mozilla.org/MPL/2.0/>`_
+
 
 Authors
 -------

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,17 @@ AnyBlok book examples
 
 The anyblok book example source code.
 
-In this repo you'll get a branch at the end of each chapter to help
-you to start with the expected environment before reading a chapter.
+In this master branch, each subdirectories are the content of each branches to
+avoid you to get some headkeak using ``git``
 
-In some special case we provide dedicated branch that helps to keep
-going and boring parts so you have to get the branch before the chapter.
+So if you want to helps us while fix issue in a chapter, please create
+a PR agains the according branch you get the issue.
+
+We have a branch at the end of each chapter to help
+book user to start with the expected environment before reading a chapter.
+
+In some special case we provide a dedicated branch that helps to keep
+going with boring parts before start a new chapter.
 
 Here the state of each branch
 
@@ -27,29 +33,41 @@ Here the state of each branch
 maintain
 --------
 
+We are using a branch per chapter. A script to helps to rebase each sub branches
+on top on the current branch.
+
+Then a dedicated build in the master branch to agregate each branches in a
+dedicated subdirectory to avoid gitbook users to be fluent with ``git``
+
+
 .. warning:
 
-    We often use force pushing (``git push --force``)  in this repository
+    So, we often use force pushing (``git push --force``)  in this repository
 
 
 Why
 ~~~
 
 - To automate change propagation over the book using rebases.
-- Provide to AnyBlok beginners reading the AnyBlok book a linear commit history
+- To provide a linear commit history
+- To avoid AnyBlok Book reader's using git over chapters
 
 How
 ~~~
+.. note:
+
+    Begore managing those changes, you should grant push right on this repo. Other
+    wise make a PR against the right branch !
 
 In this master branch, a script is provided to automaticly rebase
 all child branches according their names. If a rebase has conflict
 the script will stop to let you fix it before carry on.
 
-So you can introduce a change somewhere in the book and it will be
+So you can introduce a change somewhere in the book, or merge a PR and it will be
 visible in all following branches to recreate a linear history
-from where you introduce that change.
+from where the change were introduce.
 
-* Checkout the branche and introduce your change
+* Checkout the branche and introduce your change or merge a PR.
 * commit that change
 * clone this repo and checkout the master branch in an other directory on
   your computer
@@ -57,6 +75,8 @@ from where you introduce that change.
 * run test all to run test on each branches
 * run push all to push using the force on each branches
 
+To update the master branch, manually restart travis master branch job or
+wait a the weekly build !
 
 
 License


### PR DESCRIPTION
In this PR I would like to write a scrpt to make easy to report a change made in chapter 2 to the following chapters.

I use to try different strategy, cherry pick was error prone and hard to manage over the time, history was ugly.


Then the idea is to play with rebase over next chapters branch on top of the new change introduce to a given chapter. The output will be a linear git history that makes easy readers to understand the way to build it.

This introduce the need to  ! 

I'm on the way to test this rebase strategy which will re-write the full history each time we merge a PR and will require to use **the force** in this repo (``git push -f``).
This may give some complication if we are a lot of maintainer on this repo with a lot of contribution... which is, sadely, not the case yet !

If you have a better idea, please let me know